### PR TITLE
fix daemon invocation in the freebsd rc file

### DIFF
--- a/misc/freebsd/rc
+++ b/misc/freebsd/rc
@@ -14,11 +14,11 @@ rcvar="eventline_enable"
 : ${eventline_cfg_path:="/usr/local/etc/eventline/eventline.yaml"}
 : ${eventline_syslog_tag:="eventline"}
 
-procname="/usr/local/bin/eventline"
+procname="daemon"
 pidfile="/var/run/eventline/$name.pid"
 
 command="/usr/sbin/daemon"
-command_args="-p $pidfile -u $name -T $eventline_syslog_tag -R 5 $procname -c $eventline_cfg_path"
+command_args="-P $pidfile -u $name -T $eventline_syslog_tag -R 5 /usr/local/bin/eventline -c $eventline_cfg_path"
 
 required_files="$eventline_cfg_path"
 


### PR DESCRIPTION
When using daemon's supervision mode, we need to log the parent's pid so that the supervisor gets killed. If we log the child's pid, it will just get restarted by the supervisor. This way the supervisor will receive the term signal and relay it to eventline, but for this to work we also need to rename the procname to match what the pid points to.

Tested on `FreeBSD 13.1-RELEASE-p1 GENERIC amd64`.